### PR TITLE
Temp Good

### DIFF
--- a/selfdrive/ui/qt/sidebar.cc
+++ b/selfdrive/ui/qt/sidebar.cc
@@ -59,12 +59,12 @@ void Sidebar::updateState(const UIState &s) {
   }
   setProperty("connectStatus", QVariant::fromValue(connectStatus));
 
-  ItemStatus tempStatus = {"HIGH\nTEMP", danger_color};
+  ItemStatus tempStatus = {"TEMP\nHIGH", danger_color};
   auto ts = deviceState.getThermalStatus();
   if (ts == cereal::DeviceState::ThermalStatus::GREEN) {
-    tempStatus = {"GOOD\nTEMP", good_color};
+    tempStatus = {"TEMP\nGOOD", good_color};
   } else if (ts == cereal::DeviceState::ThermalStatus::YELLOW) {
-    tempStatus = {"OK\nTEMP", warning_color};
+    tempStatus = {"TEMP\nOK", warning_color};
   }
   setProperty("tempStatus", QVariant::fromValue(tempStatus));
 


### PR DESCRIPTION
This fixes the out of order nature of the current:

GOOD (status)
TEMP (variable)

I believe it should read

TEMP (variable)
GOOD (status)

which puts it in line with 

CONNECT
ONLINE

CONNECT
OFFLINE

CONNECT
ERROR

ETC...

I left the variable in selfdrive/thermald/thermald.py  

  startup_conditions["device_temp_good"]

as is because of the naming convention